### PR TITLE
Add containerd version set in common/defaults/main.yml

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -1,0 +1,1 @@
+containerd_version: "1.6.8-1"

--- a/roles/common/tasks/containerd.yml
+++ b/roles/common/tasks/containerd.yml
@@ -2,11 +2,7 @@
   become: yes
   ansible.builtin.apt:
     state: present
-    pkg:
-      - docker-ce
-      - docker-ce-cli
-      - containerd.io
-      - docker-compose-plugin
+    name: "containerd.io={{ containerd_version }}"
     update_cache: yes
   environment:
     DEBIAN_FRONTEND: noninteractive


### PR DESCRIPTION
Closes #1.
- Adds containerd version in common/defaults/main.yml
- Installs only containerd from the docker repo (no docker-ce, docker-ce-cli, or docker-compose-plugin required)