### PR TITLE
Add ansible_hostname as the nodeRegistration.name, instead of hardcoding

### DIFF
--- a/roles/kubeadm-init/templates/config.yml.j2
+++ b/roles/kubeadm-init/templates/config.yml.j2
@@ -14,7 +14,7 @@ localAPIEndpoint:
 nodeRegistration:
   criSocket: unix:///var/run/containerd/containerd.sock
   imagePullPolicy: IfNotPresent
-  name: k8s-master
+  name: {{ ansible_hostname }}
   taints: null
 ---
 apiServer:


### PR DESCRIPTION
Closes #4 
- Changes the nodeRegistration.name variable in the kubeadm config file to be equal to the ansible_hostname rather than a hardcoded "k8s-master" nor the investory_hostname.