### PR TITLE
Feature/19 ingress and selfsigned certs for main services

### DIFF
--- a/group_vars/master-template.yml
+++ b/group_vars/master-template.yml
@@ -4,15 +4,26 @@ metallb_ip_range: 192.168.0.6-192.168.0.9
 ingress_nginx:
   ip: 192.168.0.6
 
-# Lets Encrypt details below
-cert_manager:
-  env: production
-  server: https://acme-v02.api.letsencrypt.org/directory
-  email: << YOUR EMAIL >>
-
 # Slack details for monitoring
 slack_api: << SUPER SECRET SLACK API >>
 slack_channel: kubernetes-cluster
 
 pod_cidr: 10.244.0.0/16
 service_cidr: 10.96.0.0/16
+
+# Set all the following hostnames below to point to the ingress_nginx.ip field above
+vault:
+  host: << YOUR HOST NAME >>
+  tls: vault-tls
+
+prometheus:
+  host: << YOUR HOST NAME >>
+  tls: prometheus-tls
+
+grafana:
+  host: << YOUR HOST NAME >>
+  tls: grafana-tls
+
+dashboard:
+  host: << YOUR HOST NAME >>
+  tls: kubernetes-dashboard-tls

--- a/roles/charts/cert-manager/templates/cluster-issuer.yml.j2
+++ b/roles/charts/cert-manager/templates/cluster-issuer.yml.j2
@@ -1,14 +1,6 @@
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
-  name: letsencrypt-{{ cert_manager['env'] }}
+  name: selfsigned-cluster-issuer
 spec:
-  acme:
-    server: {{ cert_manager['server'] }}
-    email: {{ cert_manager['email'] }} 
-    privateKeySecretRef:
-      name: letsencrypt-{{ cert_manager['env'] }}
-    solvers:
-      - http01:
-          ingress:
-            class: nginx
+  selfSigned: {}

--- a/roles/charts/dashboard/tasks/main.yml
+++ b/roles/charts/dashboard/tasks/main.yml
@@ -36,3 +36,10 @@
     admin_user_role: "{{ lookup('file', './admin-user-role.yml') }}"
   environment:
     KUBECONFIG: /home/{{ ansible_user_id }}/.kube/config
+
+- name: apply dashboard certificate
+  ansible.builtin.shell: "cat <<EOF | kubectl apply -f -\n {{ ca }}\n EOF"
+  vars:
+    ca: "{{ lookup('template', './certificate.yml.j2') }}"
+  environment:
+    KUBECONFIG: /home/{{ ansible_user_id }}/.kube/config

--- a/roles/charts/dashboard/templates/certificate.yml.j2
+++ b/roles/charts/dashboard/templates/certificate.yml.j2
@@ -1,0 +1,16 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: kubernetes-dashboard-selfsigned-ca
+  namespace: kubernetes-dashboard
+spec:
+  isCA: true
+  commonName: {{ dashboard['host'] }}
+  secretName: {{ dashboard['tls'] }}
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: selfsigned-cluster-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io

--- a/roles/charts/dashboard/templates/values.yml.j2
+++ b/roles/charts/dashboard/templates/values.yml.j2
@@ -139,7 +139,7 @@ resources:
 protocolHttp: false
 
 service:
-  type: NodePort
+  type: ClusterIP
   # Dashboard service port
   externalPort: 443
 
@@ -167,7 +167,7 @@ service:
 ingress:
   ## If true, Kubernetes Dashboard Ingress will be created.
   ##
-  enabled: false
+  enabled: true
 
   ## Kubernetes Dashboard Ingress labels
   # labels:
@@ -186,7 +186,7 @@ ingress:
   #   nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
 
   ## Kubernetes Dashboard Ingress Class
-  # className: "example-lb"
+  className: "nginx"
 
   ## Kubernetes Dashboard Ingress paths
   ## Both `/` and `/*` are required to work on gce ingress.
@@ -214,15 +214,15 @@ ingress:
   ## Kubernetes Dashboard Ingress hostnames
   ## Must be provided if Ingress is enabled
   ##
-  # hosts:
-  #   - kubernetes-dashboard.domain.com
+  hosts:
+    - << dashboard['host'] >>
   ## Kubernetes Dashboard Ingress TLS configuration
   ## Secrets must be manually created in the namespace
   ##
-  # tls:
-  #   - secretName: kubernetes-dashboard-tls
-  #     hosts:
-  #       - kubernetes-dashboard.domain.com
+  tls:
+    - hosts:
+      - << dashboard['host'] >>
+      secretName: << dashboard['tls'] >>
 
 # Global dashboard settings
 settings:

--- a/roles/charts/prometheus-stack/tasks/main.yml
+++ b/roles/charts/prometheus-stack/tasks/main.yml
@@ -16,3 +16,17 @@
     update_repo_cache: yes
   environment:
     KUBECONFIG: /home/{{ ansible_user_id }}/.kube/config
+
+- name: apply prometheus certificate
+  ansible.builtin.shell: "cat <<EOF | kubectl apply -f -\n {{ ca }}\n EOF"
+  vars:
+    ca: "{{ lookup('template', './prometheus-cert.yml.j2') }}"
+  environment:
+    KUBECONFIG: /home/{{ ansible_user_id }}/.kube/config
+
+- name: apply grafana certificate
+  ansible.builtin.shell: "cat <<EOF | kubectl apply -f -\n {{ ca }}\n EOF"
+  vars:
+    ca: "{{ lookup('template', './grafana-cert.yml.j2') }}"
+  environment:
+    KUBECONFIG: /home/{{ ansible_user_id }}/.kube/config

--- a/roles/charts/prometheus-stack/templates/grafana-cert.yml.j2
+++ b/roles/charts/prometheus-stack/templates/grafana-cert.yml.j2
@@ -1,0 +1,16 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: grafana-selfsigned-ca
+  namespace: monitory
+spec:
+  isCA: true
+  commonName: {{ grafana['host'] }}
+  secretName: {{ grafana['tls'] }}
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: selfsigned-cluster-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io

--- a/roles/charts/prometheus-stack/templates/prometheus-cert.yml.j2
+++ b/roles/charts/prometheus-stack/templates/prometheus-cert.yml.j2
@@ -1,0 +1,16 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: prometheus-selfsigned-ca
+  namespace: monitory
+spec:
+  isCA: true
+  commonName: {{ prometheus['host'] }}
+  secretName: {{ prometheus['tls'] }}
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: selfsigned-cluster-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io

--- a/roles/charts/prometheus-stack/templates/values.yml.j2
+++ b/roles/charts/prometheus-stack/templates/values.yml.j2
@@ -788,12 +788,12 @@ grafana:
   ingress:
     ## If true, Grafana Ingress will be created
     ##
-    enabled: false
+    enabled: true
 
     ## IngressClassName for Grafana Ingress.
     ## Should be provided if Ingress is enable.
     ##
-    # ingressClassName: nginx
+    ingressClassName: nginx
 
     ## Annotations for Grafana Ingress
     ##
@@ -811,7 +811,8 @@ grafana:
     ##
     # hosts:
     #   - grafana.domain.com
-    hosts: []
+    hosts:
+      - << grafana['host'] >>
 
     ## Path for grafana ingress
     path: /
@@ -819,7 +820,10 @@ grafana:
     ## TLS configuration for grafana Ingress
     ## Secret must be manually created in the namespace
     ##
-    tls: []
+    tls:
+      - hosts: 
+        - << grafana['host'] >>
+        secretName: << grafana['tls'] >>
     # - secretName: grafana-general-tls
     #   hosts:
     #   - grafana.example.com
@@ -2192,11 +2196,11 @@ prometheus:
   #     someoneelse:$apr1$DMZX2Z4q$6SbQIfyuLQd.xmo/P0m2c.
 
   ingress:
-    enabled: false
+    enabled: true
 
     # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
     # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
-    # ingressClassName: nginx
+    ingressClassName: nginx
 
     annotations: {}
     labels: {}
@@ -2209,7 +2213,8 @@ prometheus:
     ##
     # hosts:
     #   - prometheus.domain.com
-    hosts: []
+    hosts:
+      - << prometheus['host'] >>
 
     ## Paths to use for ingress rules - one path should match the prometheusSpec.routePrefix
     ##
@@ -2218,13 +2223,15 @@ prometheus:
 
     ## For Kubernetes >= 1.18 you should specify the pathType (determines how Ingress paths should be matched)
     ## See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#better-path-matching-with-path-types
-    # pathType: ImplementationSpecific
+    pathType: Prefix
 
     ## TLS configuration for Prometheus Ingress
     ## Secret must be manually created in the namespace
     ##
     tls:
-      []
+      - hosts:
+        - << prometheus['host'] >>
+        secretName: << prometheus['tls'] >>
       # - secretName: prometheus-general-tls
       #   hosts:
       #     - prometheus.example.com

--- a/roles/charts/vault/tasks/main.yml
+++ b/roles/charts/vault/tasks/main.yml
@@ -16,3 +16,10 @@
     update_repo_cache: yes
   environment:
     KUBECONFIG: /home/{{ ansible_user_id }}/.kube/config
+
+- name: apply vault certificate
+  ansible.builtin.shell: "cat <<EOF | kubectl apply -f -\n {{ ca }}\n EOF"
+  vars:
+    ca: "{{ lookup('template', './certificate.yml.j2') }}"
+  environment:
+    KUBECONFIG: /home/{{ ansible_user_id }}/.kube/config

--- a/roles/charts/vault/templates/certificate.yml.j2
+++ b/roles/charts/vault/templates/certificate.yml.j2
@@ -1,0 +1,16 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: vault-selfsigned-ca
+  namespace: vault
+spec:
+  isCA: true
+  commonName: {{ vault['host'] }}
+  secretName: {{ vault['tls'] }}
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: selfsigned-cluster-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io

--- a/roles/charts/vault/templates/values.yml.j2
+++ b/roles/charts/vault/templates/values.yml.j2
@@ -357,7 +357,7 @@ server:
   # If deployment is on OpenShift, the following block is ignored.
   # In order to expose the service, use the route section below
   ingress:
-    enabled: false
+    enabled: true
     labels: {}
       # traffic: external
     annotations: {}
@@ -370,7 +370,7 @@ server:
 
     # Optionally use ingressClassName instead of deprecated annotation.
     # See: https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation
-    ingressClassName: ""
+    ingressClassName: "nginx"
 
     # As of Kubernetes 1.19, all Ingress Paths must have a pathType configured. The default value below should be sufficient in most cases.
     # See: https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types for other possible values.
@@ -380,7 +380,7 @@ server:
     # configure the ingress to point to the Vault active service.
     activeService: true
     hosts:
-      - host: chart-example.local
+      - host: << vault['host'] >>
         paths: []
     ## Extra paths to prepend to the host configuration. This is useful when working with annotation based services.
     extraPaths: []
@@ -390,7 +390,10 @@ server:
     #       name: ssl-redirect
     #       port:
     #         number: use-annotation
-    tls: []
+    tls:
+      - hosts:
+          - << vault['host'] >>
+        secretName: << vault['tls'] >>
     #  - secretName: chart-example-tls
     #    hosts:
     #      - chart-example.local

--- a/roles/cni/defaults/main.yml
+++ b/roles/cni/defaults/main.yml
@@ -1,0 +1,1 @@
+calico_manifests: https://raw.githubusercontent.com/projectcalico/calico/v3.24.1/manifests/calico.yaml

--- a/roles/cni/tasks/calico.yml
+++ b/roles/cni/tasks/calico.yml
@@ -1,5 +1,5 @@
 - name: retrieve calico networking manifests
-  ansible.builtin.shell: curl https://raw.githubusercontent.com/projectcalico/calico/v3.24.1/manifests/calico.yaml -O
+  ansible.builtin.shell: curl {{ calico_manifests }} -O
 
 - name: install calico resources
   ansible.builtin.shell: kubectl apply -f calico.yaml


### PR DESCRIPTION
Closes #19.

Add certs for dashboard, prometheus, grafana, and vault and then enable ingress in each of their values files.

Firstly, this PR creates a self signed cluster issuer in cert-manager.
Then, it uses this for all the four main services so far to enable TLS and ingress.
This PR also separates the applications of calico manifests from the link to them.